### PR TITLE
Improved support for Rider specific color scheme constructs

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -4458,6 +4458,32 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
+    <option name="ReSharper.FORMAT_STRING_ITEM">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
+    <option name="ReSharper.FORMAT_STRING_ITEM_2">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
+    <option name="ReSharper.HINT">
+      <value>
+        <option name="EFFECT_COLOR" value="a3be8c" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="ReSharper.MATCHED_FORMAT_STRING_ITEM">
+      <value>
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="ReSharper.STRING_ESCAPE_CHARACTER_2">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
     <option name="SASS_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
@@ -4960,6 +4986,13 @@
     <option name="STYLUS_IDENT">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SUGGESTION">
+      <value>
+        <option name="EFFECT_COLOR" value="a3be8c" />
+        <option name="ERROR_STRIPE_COLOR" value="a3be8c" />
+        <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
     <option name="Scala Immutable Collection">


### PR DESCRIPTION
Fixes #142. 
For an example on how the changes look like in Rider see the following image: 
![image](https://user-images.githubusercontent.com/104892491/230730413-e1ec4df0-6e4e-4b81-b3a9-1207253f10b0.png)

